### PR TITLE
Use NSC_CACHE_PATH to refer to the cache dir.

### DIFF
--- a/.github/workflows/with-volume.yaml
+++ b/.github/workflows/with-volume.yaml
@@ -20,8 +20,8 @@ jobs:
 
       - name: Touch
         run: |
-          ls /cache/
-          touch "/cache/$(date -Iseconds).txt"
+          ls "$NSC_CACHE_PATH"
+          touch "$NSC_CACHE_PATH/$(date -Iseconds).txt"
 
       - name: Mount cache
         id: cache-downloads


### PR DESCRIPTION
So if we switch the runner to macos, it would also work correctly.